### PR TITLE
made shell tasks execute npm scripts for better cross platform support

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -1,27 +1,27 @@
-var gulp  = require('gulp')
-var shell = require('gulp-shell')
+var gulp  = require('gulp');
+var shell = require('gulp-shell');
 
 // Zip directory ( Working in Linux and OSX)
 gulp.task('zip', shell.task([
   'zip -r app.nw .'
-]))
+]));
 
 // Run project
 gulp.task('run', shell.task([
-  'node_modules/node-webkit-builder/bin/nwbuild --run ./'
-]))
+  'npm run run'
+]));
 
 // Compile project
 gulp.task('osx', shell.task([
-  'node_modules/node-webkit-builder/bin/nwbuild -p osx ./'
-]))
+  'npm run osx'
+]));
 
 // Compile project
 gulp.task('win', shell.task([
-  'node_modules/node-webkit-builder/bin/nwbuild -p win ./'
-]))
+  'npm run win'
+]));
 
 // Compile project
 gulp.task('linux', shell.task([
-  'node_modules/node-webkit-builder/bin/nwbuild -p linux32,linux64 ./'
-]))
+  'npm run linux'
+]));

--- a/templates/package.json
+++ b/templates/package.json
@@ -15,6 +15,12 @@
   "repository": {
     "url": "<%= appRepository %>"
   },
+  "scripts": {
+    "run": "nwbuild --run ./",
+    "win": "nwbuild -p win ./",
+    "linux": "nwbuild -p linux32,linux64 ./",
+    "osx": "nwbuild -p osx ./"
+  },
   "author": {
     "name": "<%= appAuthor %>",
     "url": "<%= appEmail %>"


### PR DESCRIPTION
I couldn't get this project to work on Windows at first, and didn't want to mess around with bash profiles and environment variables. Thankfully, there was a much cleaner solution that involves a feature of `npm`: scripts.

When node modules install, a `.bin` folder is created and any module binaries are placed in it, and the `"scripts"` section of `package.json` can reference these binaries just by their name. This got it working 100% on windows, save for the "zip" operation which I have yet to test out a solution for.
